### PR TITLE
修复弹幕顺序导致判断遮挡错误从而丢失弹幕

### DIFF
--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -78,7 +78,7 @@ impl Canvas {
             crate::danmu::DanmuType::Bottom
             | crate::danmu::DanmuType::Top
             | crate::danmu::DanmuType::Reverse => {
-                // 不喜欢底部弹幕，直接转成 Bottom
+                // 不喜欢底部弹幕，直接转成 Float
                 // 这是 feature 不是 bug
                 danmu.r#type = crate::danmu::DanmuType::Float;
                 Ok(self.draw_float(danmu))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::HashSet,
     fs::File,
     io::{StdoutLock, Write},
@@ -396,8 +397,13 @@ where
     let mut canvas = canvas_config.canvas();
     let t = std::time::Instant::now();
 
-    for danmu in data_provider {
-        let danmu = danmu?;
+    let mut danmus = data_provider.collect::<Result<Vec<_>>>()?;
+    danmus.sort_by(|a, b| {
+        a.timeline_s
+            .partial_cmp(&b.timeline_s)
+            .unwrap_or(Ordering::Equal)
+    });
+    for danmu in danmus {
         if let Some(denylist) = denylist.as_ref() {
             if denylist.iter().any(|s| danmu.content.contains(s)) {
                 continue;


### PR DESCRIPTION
因为 `lane.rs` 的 `available_for` 是根据上一次弹幕的时间和长度计算碰撞的（`last_shoot_time` ，`last_length`）。
但是 yt-dlp 下载下来的 xml 弹幕顺序不是按时间排序的，从而导致碰撞计算错误。